### PR TITLE
refactor: 針對 gsheet_manager 和 SheetScraper 的優化

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,7 +21,9 @@ def start_suite_test(suite: TestSuite, sheet_manager: GsheetManager):
     # get data from suite tab
     sheet_manager.open_worksheet(suite.suite_name)
     cases = sheet_manager.get_steps()
+    # Test Case
     for case in cases:
+        print('# ' + case['name'])
         suite.start_case(case)
         for step_report in suite.report[-1]['report']:
             sheet_manager.update_result(step_report, 6)
@@ -35,16 +37,19 @@ def start_suite_test(suite: TestSuite, sheet_manager: GsheetManager):
 
 def main():
     # init
+    print("<< Starting SheetScraper >>")
     os.makedirs("output/", exist_ok=True)
     sheet_url = os.getenv('TEST_PLAN')
     api_key_path = os.getenv('GOOGLE_SHEET_API_KEY_FILE')
 
     # Read from Google sheet
+    print("Reading Google sheet...")
     sheet_manager = GsheetManager(api_key_path, sheet_url)
     sheet_manager.open_worksheet('plan')
     plans = sheet_manager.get_plan()
 
     # Webdriver
+    print("Creating Webdriver...")
     options = webdriver.ChromeOptions()
     options.add_argument("incognito")
     options.add_argument("headless")
@@ -52,11 +57,14 @@ def main():
     driver = webdriver.Chrome(options=options)
     driver.maximize_window()
 
+    # Test Suite
     for i in range(len(plans)):
         suite = TestSuite(driver, plans[i]["host"], plans[i]["suite"], {
             "auth": bool(plans[i]["auth"] == 'TRUE'),
             "snapshot": bool(plans[i]["snapshot"] == 'TRUE')
         })
+        print("========================================")
+        print("[ Test Suite: " + suite.suite_name + " ]")
 
         start_suite_test(suite, sheet_manager)
         sheet_manager.open_worksheet(suite.suite_name)
@@ -67,6 +75,8 @@ def main():
         sheet_manager.open_worksheet('plan')
         sheet_manager.update_result(plans[i], 1)
 
+    print("========================================")
+    print("FINISHED!")
     driver.quit()
 
 

--- a/main.py
+++ b/main.py
@@ -11,8 +11,7 @@ def start_suite_test(suite: TestSuite, sheet_manager: GsheetManager):
     # auth
     if suite.options['auth']:
         # get auth by host
-        sheet_manager.set_sheet_name('auth')
-        sheet_manager.open_worksheet()
+        sheet_manager.open_worksheet('auth')
         auth_steps = sheet_manager.search_by_step_name(suite.host)
         suite.start_auth(auth_steps['steps'])
 
@@ -20,8 +19,7 @@ def start_suite_test(suite: TestSuite, sheet_manager: GsheetManager):
         suite.jump_to_page(suite.host)
 
     # get data from suite tab
-    sheet_manager.set_sheet_name(suite.suite_name)
-    sheet_manager.open_worksheet()
+    sheet_manager.open_worksheet(suite.suite_name)
     cases = sheet_manager.get_steps()
     for case in cases:
         suite.start_case(case)
@@ -43,8 +41,7 @@ def main():
 
     # Read from Google sheet
     sheet_manager = GsheetManager(api_key_path, sheet_url)
-    sheet_manager.set_sheet_name('plan')
-    sheet_manager.open_worksheet()
+    sheet_manager.open_worksheet('plan')
     plans = sheet_manager.get_plan()
 
     # Webdriver
@@ -62,11 +59,11 @@ def main():
         })
 
         start_suite_test(suite, sheet_manager)
-        suite_sheet = sheet_manager.open_worksheet()
-        results = suite_sheet.get_col(6)
+        sheet_manager.open_worksheet(suite.suite_name)
+        results = sheet_manager.sheet.get_col(6)
         plans[i]['name'] = plans[i]['suite']
         plans[i]['result'] = suite.get_result_from_list(results)
-        sheet_manager.set_sheet_name('plan')
+        sheet_manager.open_worksheet('plan')
         sheet_manager.update_suite_result_to_col([plans[i]], 1)
 
     driver.quit()

--- a/main.py
+++ b/main.py
@@ -23,14 +23,14 @@ def start_suite_test(suite: TestSuite, sheet_manager: GsheetManager):
     cases = sheet_manager.get_steps()
     for case in cases:
         suite.start_case(case)
-        sheet_manager.update_step_result_to_col(suite.report[-1], 6)
+        for step_report in suite.report[-1]['report']:
+            sheet_manager.update_result(step_report, 6)
 
     # Report
     for i in range(len(suite.report)):
-        success_steps = [step['result'] for step in suite.report[i]['report']]
-        suite.report[i]['result'] = suite.get_result_from_list(success_steps)
-
-    sheet_manager.update_case_result_to_col(suite.report, 6)
+        step_results = [step['result'] for step in suite.report[i]['report']]
+        suite.report[i]['result'] = suite.get_result_from_list(step_results)
+        sheet_manager.update_result(suite.report[i], 6)
 
 
 def main():
@@ -62,9 +62,10 @@ def main():
         sheet_manager.open_worksheet(suite.suite_name)
         results = sheet_manager.sheet.get_col(6)
         plans[i]['name'] = plans[i]['suite']
+        plans[i]['row'] = i + 2
         plans[i]['result'] = suite.get_result_from_list(results)
         sheet_manager.open_worksheet('plan')
-        sheet_manager.update_suite_result_to_col([plans[i]], 1)
+        sheet_manager.update_result(plans[i], 1)
 
     driver.quit()
 

--- a/scraper/test_suite.py
+++ b/scraper/test_suite.py
@@ -41,10 +41,17 @@ class TestSuite:
         case_report = {"name": case["name"], "row": case["row"], "report": []}
         i = 1
         for step in case['steps']:
+            step_print = str(i) + ": " + step['action_type']
+            if step['by_method'] != 'None':
+                step_print += f"({step['by_method']}|{step['by_value']}) "
+            step_print += f" -> {step['value']}"
+            print(step_print)
+
             if step['action_type'][:6] == 'check_':
                 result = self.check_test(step)
                 case_report['report'].append(
                     {'step': i, 'row': step['row'], 'action': step['action_type'], 'value': step['value'], 'result': result})
+                print("    => " + result)
 
             else:
                 self.start_step(step)

--- a/scraper/test_suite.py
+++ b/scraper/test_suite.py
@@ -38,13 +38,13 @@ class TestSuite:
         self.report = []
 
     def start_case(self, case: dict):
-        case_report = {"name": case["name"], "report": []}
+        case_report = {"name": case["name"], "row": case["row"], "report": []}
         i = 1
         for step in case['steps']:
             if step['action_type'][:6] == 'check_':
                 result = self.check_test(step)
                 case_report['report'].append(
-                    {'step': i, 'action': step['action_type'], 'value': step['value'], 'result': result})
+                    {'step': i, 'row': step['row'], 'action': step['action_type'], 'value': step['value'], 'result': result})
 
             else:
                 self.start_step(step)
@@ -77,7 +77,7 @@ class TestSuite:
         except Exception as e:
             print(e)
 
-    def check_test(self, step):
+    def check_test(self, step: dict) -> str:
         element = Element.from_dict(step)
 
         try:
@@ -96,7 +96,7 @@ class TestSuite:
             print(e)
             return 'except failure'
 
-    def check_css(self, element: Element):
+    def check_css(self, element: Element) -> str:
         value = json.loads(element.value)
         result = []
 
@@ -109,7 +109,7 @@ class TestSuite:
 
         return result
 
-    def check_link(self, element: Element):
+    def check_link(self, element: Element) -> str:
         target_url = urljoin(self.host, element.value)
 
         if element.by_method != 'None':
@@ -121,7 +121,7 @@ class TestSuite:
         else:
             return 'failure'
 
-    def get_result_from_list(self, result_list):
+    def get_result_from_list(self, result_list: list) -> str:
         if 'failure' in result_list or 'except failure' in result_list:
             return 'failure'
         return 'success'
@@ -148,7 +148,7 @@ class TestSuite:
         original_size = self.driver.get_window_size()
         self.driver.set_window_size(width, original_size['height'])
 
-    def save_screenshot(self, path):
+    def save_screenshot(self, path: str):
         original_size = self.driver.get_window_size()
         required_width = self.driver.execute_script('return document.body.parentNode.scrollWidth')
         required_height = self.driver.execute_script('return document.body.parentNode.scrollHeight')


### PR DESCRIPTION
### 描述
1. 將 `set_sheet_name(name)` 和 `open_worksheet()` 合併為 `open_worksheet(name)`
2. 在讀取測試計畫時就將行數的資訊存入回傳資料中
3. 在 terminal 顯示輔助的運作資訊

### 變更內容
這個 PR 包括了三個相關的提交，針對 gsheet_manager 和 SheetScraper 進行了一系列優化：

1. **簡化 open_worksheet 並改善 gsheet_manager**  
   - 在 `main.py` 中將 `set_sheet_name(name)` 和 `open_worksheet()` 合併為 `open_worksheet(name)`。
   - 在 `scraper/gsheet_manager` 中新增 `sheet` 屬性以保存當前的 worksheet。
   - 修改 `open_worksheet` 方法以將結果儲存在 `self.sheet` 中。
   - 移除不需要的 `dotenv` 模組引用。
   - 為某些方法參數指定型別。

4. **優化 gsheet_manager 的測試結果更新功能**  
   - 在 `scraper/gsheet_manager` 中，在 `get_steps()` 方法中追加每個步驟的行數資訊。
   - 將所有更新測試結果的方法統一為接受單一測試報告（report）。
   - 為某些方法參數指定型別。
   - 在 `scraper/test_suite` 中，在 `case_report` 中儲存行數資訊。

5. **增加 terminal 顯示的當前運作資訊**  
   - 在 `SheetScraper` 中新增顯示測試進度的輔助訊息，透過 `print()` 方法呈現。
